### PR TITLE
Fix concatenating multiple query params

### DIFF
--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/Testing.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/Testing.kt
@@ -12,7 +12,7 @@ class Testing {
     val socket = Socket(
         endpoint = "https://socketio-chat-h9jt.herokuapp.com",
         config = SocketOptions(
-            queryParams = null,
+            queryParams = mapOf("param1" to "1", "param2" to "2"),
             transport = SocketOptions.Transport.WEBSOCKET
         )
     ) {

--- a/socket-io/src/commonJvm/kotlin/dev/icerock/moko/socket/Socket.kt
+++ b/socket-io/src/commonJvm/kotlin/dev/icerock/moko/socket/Socket.kt
@@ -33,12 +33,8 @@ actual class Socket actual constructor(
             query = config?.queryParams?.run {
                 if (size == 0) return@run null
 
-                var result = ""
-                forEach { (key, value) ->
-                    result += "$key=$value"
-                }
-
-                result
+                val params = map { (key, value) -> "$key=$value"}
+                params.joinToString("&")
             }
         })
 


### PR DESCRIPTION
The concatenation of 2 or more query params worked incorrectly. As a result, it was missing `&` symbols between values
ex. `https://hostname/?param1=1param=2`
 